### PR TITLE
ios8-facebook issue fixed

### DIFF
--- a/iOS/Renderers/LoginPageRenderer.cs
+++ b/iOS/Renderers/LoginPageRenderer.cs
@@ -35,7 +35,9 @@ namespace OAuthTwoDemo.XForms.iOS
 
 				auth.Completed += (sender, eventArgs) => {
 					// We presented the UI, so it's up to us to dimiss it on iOS.
+					DismissViewController (true, null);
 					App.Instance.SuccessfulLoginAction.Invoke();
+					
 
 					if (eventArgs.IsAuthenticated) {
 						// Use eventArgs.Account to do wonderful things


### PR DESCRIPTION
in ios8 the view won't close after retrieving the token from Facebook. Added the DismissViewController to close the view
